### PR TITLE
Fix segfault on arm machines

### DIFF
--- a/src/havegetune.c
+++ b/src/havegetune.c
@@ -795,6 +795,8 @@ static int vfs_configInfoCache(
          ctype = vfs_configFile(pAnchor, path, vfs_configType);
          strcpy(path+plen, "size");
          size  = vfs_configFile(pAnchor, path, vfs_configInt);
+	 if (size == -1)
+		 size = ctype == 'I' ? GENERIC_ICACHE : GENERIC_DCACHE;
          cfg_cacheAdd(pAnchor, SRC_VFS_INDEX,  pArgs[1], level, ctype, size);
          }
      }


### PR DESCRIPTION
Some ARM cpus does not report the cache size or say it is -1 in sysfs.
It has been observed on xgene and thunderx machines.

Fall back to the generic cache size when that happens so we don't
segfault.

Should fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=866306