### PR TITLE
Fix haveged diagnostics capture mode

### DIFF
--- a/src/havegecollect.c
+++ b/src/havegecollect.c
@@ -194,10 +194,10 @@ H_COLLECT *havege_ndcreate(/* RETURN: NULL on failure          */
             H_UINT t0=0;
             
             (void)havege_gather(h_ctxt);           /* first sample   */
-            t0 = h_ctxt->havege_tic;
+            t0 = HTICK1;
             for(i=1;i<MININITRAND;i++)
                (void)havege_gather(h_ctxt);        /* warmup rng     */
-            if (h_ctxt->havege_tic==t0) {          /* timer stuck?   */
+            if (HTICK1==t0) {                      /* timer stuck?   */
                h_ptr->error = H_NOTIMER;
                havege_nddestroy(h_ctxt);
                return NULL;


### PR DESCRIPTION
This change resolves #9 by fixing the variable that haveged checks during the rng warmup. Previously it was checking `hctxt->havege_tic` but `h_ctxt->havege_tics[i>>3]` is what actually gets updated when in diagnostics mode. `HTICK1` correctly references the right variable in both modes.

Testing was done by checking an output can be obtained:

```
> src/haveged -r 2 -n 100
havege_diagnostic: listening socket at 3
Writing 100  output to sample
```