### PR TITLE
init.d/Makefile.am: add missing dependency

### DIFF
--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -33,7 +33,7 @@ if ENABLE_SYSTEMD
 install-exec-hook:
 	$(do_subst) < $(srcdir)/$(src_tmpl) > haveged.service;
 
-install-data-hook:
+install-data-hook: install-exec-hook
 if ENABLE_SYSTEMD_LOOKUP
 	install -p -D -m644 haveged.service $(DESTDIR)`pkg-config --variable=systemdsystemunitdir systemd`/haveged.service;
 else


### PR DESCRIPTION
install-data-hook should depend on install-exec-hook, or the
haveged.service might be installed incorrectly when build
with -j option.

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
Signed-off-by: Khem Raj <raj.khem@gmail.com>