### PR TITLE
service.redhat: update PIDFile

### DIFF
--- a/init.d/service.redhat
+++ b/init.d/service.redhat
@@ -3,7 +3,7 @@ Description=Entropy Daemon based on the HAVEGE algorithm
 
 [Service]
 Type=forking
-PIDFile=/var/run/haveged.pid
+PIDFile=/run/haveged.pid
 ExecStart=@SBIN_DIR@/haveged -w 1024 -v 1
 
 [Install]


### PR DESCRIPTION
Update PIDFile to fix the following message during the boot sequence:

"PIDFile= references path below legacy directory /var/run/, updating /var/run/haveged.pid → /run/haveged.pid;
please update the unit file accordingly."

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>