### PR TITLE
Fixup the changelog

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,11 +7,14 @@ v1.9.3 (Aug 10, 2018)
  This version implements a command mode and use it for chroot -it was 
  contributed by Dr. Werner Fink.
 
-v1.9.2 (Nov 16, 1017)
+v1.9.2 (Nov 16, 2017)
    
    This release cleans up issues that have accumulated since the last release. I retired
    several years ago, and haveged is no longer under active development. This release only
    attempts to collect and document the downstream reports I have received. 
+
+v1.9.1 (Feb 11, 2014)
+   Documentation and sample file touch-up for v1.9.
 
 v1.9   (Feb 10, 2014)
 

--- a/NEWS
+++ b/NEWS
@@ -1,17 +1,17 @@
 v1.9.4 (Aug 11, 2018)
  * Avoid misleading message if cmd socket is in use
- 
+
 v1.9.3 (Aug 10, 2018)
- I (Jirka Hladky) took over haveged upstream development and moved it to GiHub 
+ I (Jirka Hladky) took over haveged upstream development and moved it to GiHub
  https://github.com/jirka-h/haveged
- This version implements a command mode and use it for chroot -it was 
+ This version implements a command mode and use it for chroot -it was
  contributed by Dr. Werner Fink.
 
 v1.9.2 (Nov 16, 2017)
-   
+
    This release cleans up issues that have accumulated since the last release. I retired
    several years ago, and haveged is no longer under active development. This release only
-   attempts to collect and document the downstream reports I have received. 
+   attempts to collect and document the downstream reports I have received.
 
 v1.9.1 (Feb 11, 2014)
    Documentation and sample file touch-up for v1.9.
@@ -27,7 +27,7 @@ v1.9   (Feb 10, 2014)
    logic, and implementation bugs in both test procedure A and B. Attempting to diagnose
    these problems also revealed the injection feature of the diagnostic build was also
    broken.
-   
+
    Once the injection facility was fixed, an independent implementation of the AIS reference
    for procedure B was used to verify the haveged implementation down to bit level. Portions
    of the run-time test suite were rewritten to correct defects and improve performance of the
@@ -36,7 +36,7 @@ v1.9   (Feb 10, 2014)
    oriented. Unrelated changes included in the release include adding a quick version check
    for libhavege use, many small improvements to diagnostics, and more cleanup man pages,
    sample files, and other documentation.
-   
+
    Special thanks to Jirka Hladky for help in sorting out the procedure B bugs, verifying
    the haveged RNG is statistically comparable to RDRAND, and the first formal testing of
    haveged on ARM.
@@ -60,7 +60,7 @@ v1.7a  (Feb 13, 2013)
    Fix broken parallel builds - fix LDADD problem in build, VPATH problems in check targets.
    Move to check-local for check target to work with automake v1.13 but retain backward
    compatibility. Modify build to make tuning component optional in build. Improve sample
-   spec file and docs.   
+   spec file and docs.
 
 v1.7   (Jan 15, 2013)
 
@@ -68,7 +68,7 @@ v1.7   (Jan 15, 2013)
    dependency. The new contrib/build/build.sh script is intended to toggle this requirement
    as well as providing a bootstrap to recover from automake mismatches. The script will also
    build and run devel sample code for those interested in using the devel package.
-   
+
    Other build related changes include updating AC_PREQ to a more reasonable, 2.59 and changing
    the build option for init scripts to default to --enable-init=none. The format of the
    haveged diagnostic display has changed to provided more information and the output is now


### PR DESCRIPTION
1. Restore missing release v1.9.1
2. Fix release date for v1.9.2
3. Remove extraneous whitespace

(1) and (2) are from a Debian patch I'm including in `haveged/1.9.4-1` (upload pending, should hit `sid` today)