### PR TITLE
Remove support for CPUID on ia64

### DIFF
--- a/src/havegecollect.h
+++ b/src/havegecollect.h
@@ -117,11 +117,7 @@ typedef struct h_collect {
 
 #ifdef HAVE_ISA_IA64
 #define ARCH "ia64"
-#define CPUID(op,reg) ASM("mov %0=cpuid[%1]"\
-   : "=r" (value)\
-   : "r" (reg))
 #define HARDCLOCK(x) ASM("mov %0=ar.itc" : "=r"(x))
-#define HASCPUID(x) x=1
 #endif
 
 #ifdef HAVE_ISA_SPARC


### PR DESCRIPTION
The current implementation simply fail to build (on Itanium) and the `cpuid` instruction on Itanium spreads out value differently than what 'cpuid' does on i386 and amd64, so the code would need to be worked out quite differently to work.

In the meantime, disabling CPUID support will make haveged use the default cache values on ia64.