### PR TITLE
init.d/service.fedora: Merge improvements in service containment from Debian

### DIFF
--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -2,7 +2,7 @@
 Description=Entropy Daemon based on the HAVEGE algorithm
 Documentation=man:haveged(8) http://www.issihosts.com/haveged/
 DefaultDependencies=no
-After=systemd-tmpfiles-setup-dev.service
+After=systemd-tmpfiles-setup.service systemd-tmpfiles-setup-dev.service
 Before=sysinit.target shutdown.target systemd-journald.service
 
 [Service]
@@ -10,6 +10,7 @@ ExecStart=/usr/sbin/haveged -w 1024 -v 1 --Foreground
 Restart=always
 SuccessExitStatus=137 143
 CapabilityBoundingSet=CAP_SYS_ADMIN
+PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true
 ProtectSystem=full

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -9,6 +9,7 @@ Before=sysinit.target shutdown.target systemd-journald.service
 ExecStart=/usr/sbin/haveged -w 1024 -v 1 --Foreground
 Restart=always
 SuccessExitStatus=137 143
+SecureBits=noroot-locked
 CapabilityBoundingSet=CAP_SYS_ADMIN
 PrivateTmp=true
 PrivateDevices=true

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -14,6 +14,7 @@ PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true
 ProtectSystem=full
+ProtectHome=true
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
Sets the following:
- `SecureBits=noroot-locked`
- `PrivateHome=true`
- `PrivateTmp=true`