### PR TITLE
build: Fix compilation with --enable-threads

### DIFF
--- a/src/havegetune.c
+++ b/src/havegetune.c
@@ -187,7 +187,7 @@ void havege_tune(          /* RETURN: none               */
    *bp++ = BUILD_CPUID;
 #endif
 #if NUMBER_CORES>1
-   *bp++ = BUILD_THREAD;
+   *bp++ = BUILD_THREADS;
 #endif
 #ifdef ONLINE_TESTS_ENABLE
    *bp++ = BUILD_OLT;


### PR DESCRIPTION
Previously failed with:
```
havegetune.c:190:12: error: ‘BUILD_THREAD’ undeclared (first use in this function); did you mean ‘BUILD_THREADS’?
  190 |    *bp++ = BUILD_THREAD;
      |            ^~~~~~~~~~~~
      |            BUILD_THREADS
```
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>