### PR TITLE
haveged.service: Tighten-down security settings

### DIFF
--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -9,6 +9,8 @@ Before=sysinit.target shutdown.target systemd-journald.service
 ExecStart=/usr/sbin/haveged -w 1024 -v 1 --Foreground
 Restart=always
 SuccessExitStatus=137 143
+
+SecureBits=noroot-locked
 CapabilityBoundingSet=CAP_SYS_ADMIN
 PrivateDevices=true
 PrivateNetwork=true

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -16,6 +16,10 @@ PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true
 ProtectSystem=full
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
 
 [Install]
 WantedBy=sysinit.target

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -24,6 +24,7 @@ RestrictNamespaces=true
 RestrictRealtime=true
 
 LockPersonality=true
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=sysinit.target

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -12,6 +12,7 @@ SuccessExitStatus=137 143
 
 SecureBits=noroot-locked
 CapabilityBoundingSet=CAP_SYS_ADMIN
+PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true
 ProtectSystem=full

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -25,6 +25,9 @@ RestrictRealtime=true
 
 LockPersonality=true
 MemoryDenyWriteExecute=true
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @file-system @io-event @network-io @signal
+SystemCallFilter=arch_prctl brk ioctl mprotect sysinfo
 
 [Install]
 WantedBy=sysinit.target

--- a/init.d/service.fedora
+++ b/init.d/service.fedora
@@ -20,6 +20,10 @@ ProtectHome=true
 ProtectHostname=true
 ProtectKernelLogs=true
 ProtectKernelModules=true
+RestrictNamespaces=true
+RestrictRealtime=true
+
+LockPersonality=true
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
All changes were applied to `init.d/service.fedora`; I shipped them moments
ago in Debian “sid” (a.k.a. unstable) as `haveged/1.9.8-3`.

- [x] Set `SecureBits` to prevent raising capabilities through `execve(2)`
- [x] Set `PrivateTmp`, so haveged gets its own `/tmp` and cannot access that
      of other services.
- [x] Set system-protection options `Protect{Home,Hostname,Kernel{Logs,Modules}}
- [x] Disable access to potentially-vulnerable kernel features
      (namespaces, personalities, realtime scheduling)
- [x] Enforce W^X (cannot have memory that is both writeable and executable)
- [x] Add a rather-restrictive syscall filter for the service