### PR TITLE
don't use SOCK_CLOEXEC or SOCK_NONBLOCK if not available

### DIFF
--- a/src/havegecmd.h
+++ b/src/havegecmd.h
@@ -33,6 +33,14 @@ extern "C" {
 
 #define HAVEGED_SOCKET_PATH      "\0/sys/entropy/haveged"
 #define MAGIC_CHROOT             'R'
+  
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
+#endif
+
+#ifndef SOCK_NONBLOCK
+#define SOCK_NONBLOCK 0
+#endif
 
 /**
  * Open and listen on a UNIX socket to get command from there


### PR DESCRIPTION
Avoids these errors:

havegecmd.c: In function ‘cmd_listen’:
havegecmd.c:105: error: ‘SOCK_CLOEXEC’ undeclared (first use in this function)
havegecmd.c:105: error: (Each undeclared identifier is reported only once
havegecmd.c:105: error: for each function it appears in.)
havegecmd.c:105: error: ‘SOCK_NONBLOCK’ undeclared (first use in this function)
havegecmd.c: In function ‘cmd_connect’:
havegecmd.c:154: error: ‘SOCK_CLOEXEC’ undeclared (first use in this function)
havegecmd.c:154: error: ‘SOCK_NONBLOCK’ undeclared (first use in this function)