### PR TITLE
don't fail completely if we can't set write wakeup watermark

### DIFF
--- a/src/haveged.c
+++ b/src/haveged.c
@@ -694,6 +694,9 @@ static void set_watermark( /* RETURN: nothing   */
       fprintf(wm_fh, "%d\n", level);
       fclose(wm_fh);
       }
+   else if (errno == EACCES)
+       fprintf(stderr, "No access to %s, can't set watermark (maybe running in a container?)\n",
+               params->watermark);
    else error_exit("Fail:set_watermark()!");
 }
 #endif


### PR DESCRIPTION
We won't have access to change the watermark if we're running in
an unprivileged container, so if the error is EACCES just warn
and continue