### PR TITLE
haveged: fix build on uclibc

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -33,6 +33,9 @@
 /* Define to 1 if you have the `floor' function. */
 #undef HAVE_FLOOR
 
+/* Define to 1 if you have the `getauxval' function. */
+#undef HAVE_GETAUXVAL
+
 /* Define to 1 if you have the `getsockopt' function. */
 #undef HAVE_GETSOCKOPT
 
@@ -137,6 +140,9 @@
 
 /* Define to 1 if you have the <syslog.h> header file. */
 #undef HAVE_SYSLOG_H
+
+/* Define to 1 if you have the <sys/auxv.h> header file. */
+#undef HAVE_SYS_AUXV_H
 
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
 #undef HAVE_SYS_IOCTL_H

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ AC_HEADER_TIME
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_SELECT_ARGTYPES
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS([__rdtsc accept accept4 bind connect execv floor getsockopt gettimeofday listen memset pow pselect recv sched_yield select send setsockopt socket sqrt])
+AC_CHECK_FUNCS([__rdtsc accept accept4 bind connect execv floor getauxval getsockopt gettimeofday listen memset pow pselect recv sched_yield select send setsockopt socket sqrt])
 
 ## Checks for header files.
 AC_HEADER_STDC
@@ -124,6 +124,7 @@ AC_CHECK_HEADERS(stdint.h)
 AC_CHECK_HEADERS(stdio.h)
 AC_CHECK_HEADERS(stdlib.h)
 AC_CHECK_HEADERS(string.h)
+AC_CHECK_HEADERS([sys/auxv.h])
 AC_CHECK_HEADERS(sys/ioctl.h)
 AC_CHECK_HEADERS(sys/mman.h)
 AC_CHECK_HEADERS(sys/types.h)

--- a/src/haveged.c
+++ b/src/haveged.c
@@ -19,7 +19,9 @@
  ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "config.h"
+#ifdef HAVE_SYS_AUXV_H
 #include <sys/auxv.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
@@ -135,8 +137,10 @@ int main(int argc, char **argv)
 {
    volatile char *path = strdup(argv[0]);
    volatile char *arg0 = argv[0];
+#ifdef HAVE_GETAUXVAL
    if (path[0] != '/')
       path = (char*)getauxval(AT_EXECFN);
+#endif
    static const char* cmds[] = {
       "b", "buffer",      "1", SETTINGR("Buffer size [KW], default: ",COLLECT_BUFSIZE),
       "d", "data",        "1", SETTINGR("Data cache size [KB], with fallback to: ", GENERIC_DCACHE ),


### PR DESCRIPTION
Check for HAVE_GETAUXVAL or HAVE_SYS_AUXV_H before using
getauxval to avoid a build failure on uclibc

Fixes:

/bin/bash ../libtool  --tag=CC   --mode=compile /home/pjtexier/Bureau/buildroot/pj/bootlin-armv5-uclibc/host/bin/arm-linux-gcc -DHAVE_CONFIG_H -I. -I..   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wpedantic -I.. -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -c -o libhavege_la-havege.lo `test -f 'havege.c' || echo './'`havege.c
/bin/bash ../libtool  --tag=CC   --mode=compile /home/pjtexier/Bureau/buildroot/pj/bootlin-armv5-uclibc/host/bin/arm-linux-gcc -DHAVE_CONFIG_H -I. -I..   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wpedantic -I.. -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -c -o libhavege_la-havegetune.lo `test -f 'havegetune.c' || echo './'`havegetune.c
/bin/bash ../libtool  --tag=CC   --mode=compile /home/pjtexier/Bureau/buildroot/pj/bootlin-armv5-uclibc/host/bin/arm-linux-gcc -DHAVE_CONFIG_H -I. -I..   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wpedantic -I.. -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -c -o libhavege_la-havegecollect.lo `test -f 'havegecollect.c' || echo './'`havegecollect.c
/bin/bash ../libtool  --tag=CC   --mode=compile /home/pjtexier/Bureau/buildroot/pj/bootlin-armv5-uclibc/host/bin/arm-linux-gcc -DHAVE_CONFIG_H -I. -I..   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wpedantic -I.. -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -c -o libhavege_la-havegetest.lo `test -f 'havegetest.c' || echo './'`havegetest.c
haveged.c:22:10: erreur fatale: sys/auxv.h : Aucun fichier ou dossier de ce type
   22 | #include <sys/auxv.h>
      |          ^~~~~~~~~~~~
compilation terminée.

Closes: #56

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>