### PR TITLE
Synchronize haveged instances during switch root

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE([subdir-objects no-dependencies])
 AC_CONFIG_SRCDIR([src/haveged.c])
 AC_CHECK_TYPES([uint32_t, uint8_t])
-HA_LDFLAGS=""
+HA_LDFLAGS="-pthread"
 
 ##libtool_start##
 LT_INIT
@@ -73,7 +73,6 @@ AC_ARG_ENABLE(threads,
    , enable_threads="no")
 if test "x$enable_threads" = "xyes"; then
    AC_DEFINE(NUMBER_CORES, 4, [Define maxium number of collection threads])
-   HA_LDFLAGS="-pthread"
 else
    AC_DEFINE(NUMBER_CORES, 1, [Define to single collection thread])
 fi

--- a/src/havegecmd.h
+++ b/src/havegecmd.h
@@ -49,6 +49,8 @@ extern "C" {
 #define SOCK_NONBLOCK 0
 #endif
 
+#define SEM_NAME "haveged_sem"
+
 /**
  * Open and listen on a UNIX socket to get command from there
  */


### PR DESCRIPTION
We found that with some system configurations zypper and lsof were complaining about haveged using deleted file (haveged binary itself) after each reboot of the system. On kernels =< 5.6 haveged is started early in the initramfs. Before switching to the permanent rootfs, haveged was supposed to do a chdir to `/sysroot` and re-executes the haveged binary from `/sysroot`. This is supposed to be done by the `haveged-switch-root` service.

The `haveged-switch-service` failed due to a communication problem. There are 2 haveged instances running on the system when the `haveged-switch-service` is started - one haveged daemon instance and one switch instances telling the daemon to switch its root directory.

The two daemons communicate via abstract namespace unix socket. Depending on the scheduling of the process done by the kernel, some times the daemon instance is trying to read data from the socket which is not yet sent and here the problem happens. The problem is almost systematic on KVM VMs with one cpu.

This PR using a named semaphore to prevent reading from a socket until the second process has completed writing.

Thanks to @bkahla for finding this issue providing patch.