### PR TITLE
90-haveged.rules: fix warnings reported by udevadm verify

### DIFF
--- a/contrib/Fedora/90-haveged.rules
+++ b/contrib/Fedora/90-haveged.rules
@@ -1,5 +1,5 @@
 # Start the haveged service as soon as the random device is available
 # to avoid starting other services while starved of entropy
 
-ACTION=="add", KERNEL=="random" , SUBSYSTEM=="mem", TAG+="systemd", ENV{SYSTEMD_WANTS}+="haveged.service"
+ACTION=="add", KERNEL=="random", SUBSYSTEM=="mem", TAG+="systemd", ENV{SYSTEMD_WANTS}+="haveged.service"
 

--- a/contrib/SUSE/90-haveged.rules
+++ b/contrib/SUSE/90-haveged.rules
@@ -1,5 +1,5 @@
 # Start the haveged service as soon as the random device is available
 # to avoid starting other services while starved of entropy
 
-ACTION=="add", KERNEL=="random" , SUBSYSTEM=="mem", TAG+="systemd", ENV{SYSTEMD_WANTS}+="haveged.service"
+ACTION=="add", KERNEL=="random", SUBSYSTEM=="mem", TAG+="systemd", ENV{SYSTEMD_WANTS}+="haveged.service"
 


### PR DESCRIPTION
Fix the following warnings reported by udevadm verify:

```
contrib/Fedora/90-haveged.rules:4 Stray whitespace before comma.
contrib/SUSE/90-haveged.rules:4 Stray whitespace before comma.
```