### PR TITLE
Creating /dev/shm if its not existing, otherwise haveged fails to start.

### DIFF
--- a/src/haveged.c
+++ b/src/haveged.c
@@ -489,7 +489,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "%s: disabling command mode for this instance\n", params->daemon);
          }
       }
-      /* Initilize named semaphore to synchronize command instances */
+      /* Initialize named semaphore to synchronize command instances */
       if (mkdir("/dev/shm", 0755) != 0) {
         if (errno != EEXIST) {
           error_exit("Couldn't create /dev/shm directory: %s", strerror(errno));

--- a/src/haveged.c
+++ b/src/haveged.c
@@ -490,6 +490,12 @@ int main(int argc, char **argv)
          }
       }
       /* Initilize named semaphore to synchronize command instances */
+      if (mkdir("/dev/shm", 0755) != 0) {
+        if (errno != EEXIST) {
+          error_exit("Couldn't create /dev/shm directory: %s", strerror(errno));
+        }
+      }
+
       sem = sem_open(SEM_NAME, O_CREAT, 0644, 1);
       if (sem == NULL) {
          fprintf(stderr, "Warning: Couldn't create named semaphore " SEM_NAME" error: %s", strerror(errno));


### PR DESCRIPTION
Hi,

when /dev/shm doesn't exist, haveged fails to start because it can't create its semaphore. I've applied this in Debian some time ago and it would be nice if you could merge it.

Regards,
Daniel