### PR TITLE
Fix typoed comments in source and build scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ AC_ARG_ENABLE(threads,
    AS_HELP_STRING([--enable-threads=[no/yes]],[Enable threads [default=no]]),
    , enable_threads="no")
 if test "x$enable_threads" = "xyes"; then
-   AC_DEFINE(NUMBER_CORES, 4, [Define maxium number of collection threads])
+   AC_DEFINE(NUMBER_CORES, 4, [Define maximum number of collection threads])
 else
    AC_DEFINE(NUMBER_CORES, 1, [Define to single collection thread])
 fi
@@ -87,7 +87,7 @@ if test "x$enable_tune" = "xyes"; then
 elif test "x$enable_tune" = "xcpuid"; then
    AC_DEFINE(TUNING_CPUID_ENABLE, 1, [Define to 1 to tune with host cpuid])
 elif test "x$enable_tune" = "xvfs"; then
-   AC_DEFINE(TUNING_VFS_ENABLE, 1, [Define to 1 to tune wiht host vfs])
+   AC_DEFINE(TUNING_VFS_ENABLE, 1, [Define to 1 to tune with host vfs])
 fi
 
 ## Checks for programs.
@@ -152,7 +152,7 @@ else
       daemon_type="none"
    ;;
   esac
-fi 
+fi
 
 ## Match host to havegedef macros
 case "$host" in

--- a/ent/chisq.c
+++ b/ent/chisq.c
@@ -1,11 +1,11 @@
 /*
 
     Compute probability of measured Chi Square value.
-    
+
     This code was developed by Gary Perlman of the Wang
     Institute (full citation below) and has been minimally
     modified for use in this program.
-    
+
 */
 
 #include <math.h>
@@ -79,7 +79,7 @@ poz(const double z)  /*VAR normal z value */
 #define	BIGX           20.0         /* max value to represent exp (x) */
 #define	ex(x)             (((x) < -BIGX) ? 0.0 : exp(x))
 
-/*FUNCTION pochisq: probability of chi sqaure value */
+/*FUNCTION pochisq: probability of chi square value */
 /*ALGORITHM Compute probability of chi square value.
 	Adapted from:
 		Hill, I. D. and Pike, M. C.  Algorithm 299

--- a/src/havege.c
+++ b/src/havege.c
@@ -20,7 +20,7 @@
  **
  */
 /**
- * This compile unit implements the havege algorithm as an inteface to
+ * This compile unit implements the havege algorithm as an interface to
  * either a single collector in the calling process or an interface to
  * multiple collector processes (experimental).
  */
@@ -36,7 +36,7 @@
  * The library version interface results in a pair of version definitions
  * which must agree yet must also be string literals. No foolproof build
  * mechanism could be devised to ensure this, so a run-time check was added
- * instead - if the two definitions do not agree, the interface is diabled.
+ * instead - if the two definitions do not agree, the interface is disabled.
  */
 #define  INTERFACE_DISABLED() strcmp(PACKAGE_VERSION,HAVEGE_PREP_VERSION)
 
@@ -96,7 +96,7 @@ typedef struct {
 static void havege_mute(const char *format, ...);
 /**
  * Initialize the environment based upon the tuning survey. This includes,
- * allocation the output buffer (in shared memory if mult-threaded) and
+ * allocation the output buffer (in shared memory if multi-threaded) and
  * fitting the collection code to the tuning inputs.
  */
 H_PTR havege_create(             /* RETURN: app state    */
@@ -240,7 +240,7 @@ int havege_rng(            /* RETURN: number words read     */
 {
 #if NUMBER_CORES>1
    H_THREAD    *t = (H_THREAD *) h->threads;
-   
+
    t->count = sz;
    t->out   = buffer;
    if (0!=sem_post(&t->flags[t->last]))
@@ -403,7 +403,7 @@ int  havege_status_dump(   /* RETURN: output length   */
  * returns the definition of HAVEGE_PREP_VERSION used to build the library. Calling
  * with HAVEGE_PREP_VERSION as the version checks if this headers definition is
  * compatible with that of the library, returning NULL if the input is incompatible
- * with the library. 
+ * with the library.
  */
 const char *havege_version(const char *version)
 {
@@ -417,7 +417,7 @@ const char *havege_version(const char *version)
    if (version) {
       H_UINT l_interface=0, l_revision=0, l_age=0;
       H_UINT p, p_interface, p_revision, p_patch;
-      
+
 #ifdef HAVEGE_LIB_VERSION
       sscanf(HAVEGE_LIB_VERSION, "%u:%u:%u", &l_interface, &l_revision, &l_age);
 #endif
@@ -454,7 +454,7 @@ static int havege_exit(    /* RETURN: NZ if child  */
    H_THREAD *t = (H_THREAD *)h_ptr->threads;
    pid_t  p;
    H_UINT i;
-   
+
    if (0 == t)
       return 0;            /* Must be main thread */
    t->fatal = H_EXIT;
@@ -484,7 +484,7 @@ static void havege_ipc(    /* RETURN: None            */
 {
    void     *m;
    H_THREAD *t;
-   H_UINT   m_sz; 
+   H_UINT   m_sz;
    int      i;
 
    if (n > NUMBER_CORES) {
@@ -517,7 +517,7 @@ static void havege_ipc(    /* RETURN: None            */
  * If task fails after start, H_THREAD::fatal will be set to the reason and a completion
  * will be posted to prevent the main thread from hanging waiting for a response.
  */
-static int havege_rngChild(/* RETURN: none         */   
+static int havege_rngChild(/* RETURN: none         */
   H_PTR h_ptr,             /* IN: app state        */
   H_UINT cNumber)          /* IN: collector index  */
 {
@@ -543,7 +543,7 @@ static int havege_rngChild(/* RETURN: none         */
                thds->last = cNumber;
                r = h_ctxt->havege_szFill - h_ctxt->havege_nptr;
                if (thds->count < r)
-                  r = thds->count; 
+                  r = thds->count;
                for(i=0;i<r;i++)
                   thds->out[i] = havege_ndread(h_ctxt);
                thds->fatal = h_ctxt->havege_err;
@@ -591,7 +591,7 @@ static void havege_unipc(  /* RETURN: none         */
 #ifdef ONLINE_TESTS_ENABLE
 /**
  * Interpret options string as settings. The option string consists of terms
- * like "[t|c][a[1-8][w]|b[w]]". 
+ * like "[t|c][a[1-8][w]|b[w]]".
  */
 static int testsConfigure( /* RETURN: non-zero on error  */
    H_UINT *tot,            /* OUT: tot test options      */
@@ -658,7 +658,7 @@ static void testsStatus(    /* RETURN: test config     */
    procInst    *p;
    char        *dst = tot;
    H_UINT      i, j, k, m;
-   
+
    *dst = *tot = 0;
    p = tps->totTests;
    for(i=0;i<2;i++,p = tps->runTests, dst = prod) {
@@ -696,7 +696,7 @@ static void testReport(
    H_PTR       h_ptr = (H_PTR)(h_ctxt->havege_app);
    onlineTests *context = (onlineTests *) h_ctxt->havege_tests;
    char        *result;
-   
+
    switch(state) {
       case TEST_DONE:   result = "success";           break;
       case TEST_RETRY:  result = "retry";             break;
@@ -726,7 +726,7 @@ static void testReportA(       /* RETURN: nothing               */
 
    H_UINT ran[6],sum[6];
    H_UINT ct, i, j, k;
-         
+
    for (i=0;i<6;i++)
       ran[i] = sum[i] = 0;
    for(i=0;i<p->testRun;i++){
@@ -792,4 +792,3 @@ static void testReportB(       /* RETURN: nothing               */
       }
 }
 #endif
-


### PR DESCRIPTION
Correct several spelling mistakes reported by me in maintained sources:

* src/havege.c: fix “interface”, “disabled”, and “multi-threaded” in top-level documentation comments.
* configure.ac: update autoconf descriptions to say “maximum number of collection threads” and “tune with host vfs”.
* ent/chisq.c: correct “chi square” comment spelling.

Generated artifacts and vendor files flagged by me remain unchanged.

Tests: not run (not requested)

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-12-01T18:06:30Z
Repository: haveged
Branch: master
Signing: GPG (989AF9F0)
Performance: 3 files, +20/-21 lines