### PR TITLE
Use O_EXCL flag with sem_open and run sem_unlink upon exit

### DIFF
--- a/src/haveged.c
+++ b/src/haveged.c
@@ -501,7 +501,7 @@ int main(int argc, char **argv)
         chmod("/dev/shm", 01777);
       }
 
-      sem = sem_open(SEM_NAME, O_CREAT, 0644, 1);
+      sem = sem_open(SEM_NAME, O_CREAT | O_EXCL, 0644, 1);
       if (sem == SEM_FAILED) {
          fprintf(stderr, "Warning: Couldn't create named semaphore " SEM_NAME" error: %s", strerror(errno));
          fprintf(stderr, "         %s: disabling command mode for this instance\n", params->daemon);
@@ -880,6 +880,7 @@ void error_exit(           /* RETURN: nothing   */
       }
    }
    havege_destroy(handle);
+   sem_unlink(SEM_NAME);
    exit(params->exit_code);
 }
 /**


### PR DESCRIPTION
Haveged uses a predictable location for the semaphore and didn't verify if it already exists and also did not clean it upon exit.

A malicious user could create the file when Haveged is not running with e.g. `perl -e 'print "\x00"x8 . "\x80" . "\x00"x23' >/dev/shm/sem.haveged_sem` that would cause a denial of service condition when receiving commands. Haveged would get stuck in [sem_wait](https://github.com/jirka-h/haveged/blob/21bad00a09233855fbea14ac062bc72b5eabc9a6/src/havegecmd.c#L299).